### PR TITLE
cautionary pinning of biocypher version

### DIFF
--- a/data/requirements.txt
+++ b/data/requirements.txt
@@ -1,5 +1,5 @@
 pyyaml
 python-arango
-git+https://github.com/saezlab/BioCypher.git
+git+https://github.com/saezlab/BioCypher.git@v0.4.3
 pytest
 pytest-mock


### PR DESCRIPTION
i did a refactor for OWL ontology backend with potential breaking changes (needs updating the config file), so I propose to pin the current version to avoid problems with that.