### PR TITLE
[DSERV-120] Adding json output for Favor adaptor

### DIFF
--- a/data/adapters/__init__.py
+++ b/data/adapters/__init__.py
@@ -48,6 +48,9 @@ class Adapter:
         Adapter.get_biocypher().show_ontology_structure()
 
     def write_file(self):
+        if getattr(self, 'SKIP_BIOCYPHER', None):
+            return
+
         if self.element_type == 'edge':
             Adapter.get_biocypher().write_edges(self.process_file())
         elif self.element_type == 'node':

--- a/data/adapters/helpers.py
+++ b/data/adapters/helpers.py
@@ -1,4 +1,5 @@
 from inspect import getfullargspec
+import hashlib
 
 ALLOWED_ASSEMBLIES = ['GRCh38']
 
@@ -21,7 +22,9 @@ def assembly_check(id_builder):
 @assembly_check
 def build_variant_id(chr, pos_first_ref_base, ref_seq, alt_seq, assembly='GRCh38'):
     # pos_first_ref_base: 1-based position
-    return '{}_{}_{}_{}_{}'.format(chr, pos_first_ref_base, ref_seq, alt_seq, assembly)
+    key = '{}_{}_{}_{}_{}'.format(
+        chr, pos_first_ref_base, ref_seq, alt_seq, assembly)
+    return hashlib.sha256(key.encode()).hexdigest()
 
 
 @assembly_check

--- a/data/db/arango_db.py
+++ b/data/db/arango_db.py
@@ -74,6 +74,15 @@ class ArangoDB:
 
         return cmds
 
+    # currently only supporting nodes
+    def generate_json_import_statement(self, data_filepath, collection):
+        cmds = []
+
+        cmds.append(
+            'arangoimp --file {} --collection {} --create-collection'.format(data_filepath, collection))
+
+        return cmds
+
     def create_custom_analyzer(self, db, analyzer):
         if analyzer == 'text_en_no_stem':
             db.create_analyzer(

--- a/data/tests/test_adapter.py
+++ b/data/tests/test_adapter.py
@@ -138,6 +138,29 @@ def test_adapter_writes_nodes(mock_op):
         mock_bio.write_nodes.assert_called_with('Test file processed')
 
 
+@patch('builtins.open', new_callable=mock_open, read_data=MOCK_TEST_NODE)
+def test_adapter_writes_nodes_skips_biocypher(mock_op):
+    mock_bio = Mock()
+
+    with patch('adapters.Adapter.get_biocypher', return_value=mock_bio) as mock_driver:
+        class TestAdapter(Adapter):
+            SKIP_BIOCYPHER = True
+
+            def __init__(self):
+                self.dataset = 'test node'
+
+                super(TestAdapter, self).__init__()
+
+            def process_file(self):
+                return 'Test file processed'
+
+        adapter = TestAdapter()
+
+        adapter.write_file()
+
+        mock_bio.write_nodes.assert_not_called()
+
+
 @patch('adapters.ArangoDB')
 @patch('builtins.open', new_callable=mock_open, read_data=MOCK_TEST_NODE)
 def test_adapter_generate_arangodb_import_sts_per_chr(mock_op, mock_arango):

--- a/data/tests/test_arango_db.py
+++ b/data/tests/test_arango_db.py
@@ -193,6 +193,18 @@ def test_arangodb_generates_import_statements_for_edges(mock_client):
 
 
 @patch('db.arango_db.ArangoClient')
+def test_arangodb_generates_import_json_statements(mock_client):
+    with patch('builtins.open', new_callable=mock_open, read_data=MOCK_CONFIG_FILE) as mock_op:
+        db = ArangoDB()
+
+        cmds = db.generate_json_import_statement('data.csv', 'test_collection')
+
+        import_st_1 = 'arangoimp --file data.csv --collection test_collection --create-collection'
+
+        assert cmds == [import_st_1]
+
+
+@patch('db.arango_db.ArangoClient')
 @patch('builtins.open', new_callable=mock_open, read_data=MOCK_CONFIG_FILE)
 def test_arangodb_creates_persistent_index(mock_op, mock_client):
     db = ArangoDB()

--- a/data/tests/test_helpers.py
+++ b/data/tests/test_helpers.py
@@ -1,4 +1,5 @@
 import pytest
+import hashlib
 from adapters.helpers import build_variant_id, build_accessible_dna_region_id
 
 
@@ -21,20 +22,8 @@ def test_build_variant_id_creates_id_string():
     assembly = 'GRCh38'
 
     variant_id = build_variant_id(chr, pos, ref_seq, alt_seq, assembly)
-
-    assert variant_id == '{}_{}_{}_{}_{}'.format(
-        chr, pos, ref_seq, alt_seq, 'GRCh38')
-
-
-def test_build_open_chromatic_region_id_fails_for_unsupported_assembly():
-    with pytest.raises(ValueError, match='Assembly not supported'):
-        build_accessible_dna_region_id(None, None, None, 'hg19')
-
-    try:
-        build_accessible_dna_region_id(None, None, None, 'GRCh38')
-        build_accessible_dna_region_id(None, None, None)
-    except:
-        assert False, 'build_chromatic_region_id raised exception for GRCh38'
+    assert variant_id == hashlib.sha256('{}_{}_{}_{}_{}'.format(
+        chr, pos, ref_seq, alt_seq, 'GRCh38').encode()).hexdigest()
 
 
 def test_build_variant_id_creates_id_string():
@@ -46,3 +35,14 @@ def test_build_variant_id_creates_id_string():
     id = build_accessible_dna_region_id(chr, pos_start, pos_end, assembly)
 
     assert id == '{}_{}_{}_{}'.format(chr, pos_start, pos_end, assembly)
+
+
+def test_build_open_chromatic_region_id_fails_for_unsupported_assembly():
+    with pytest.raises(ValueError, match='Assembly not supported'):
+        build_accessible_dna_region_id(None, None, None, 'hg19')
+
+    try:
+        build_accessible_dna_region_id(None, None, None, 'GRCh38')
+        build_accessible_dna_region_id(None, None, None)
+    except:
+        assert False, 'build_chromatic_region_id raised exception for GRCh38'


### PR DESCRIPTION
Favor has an object (the frequencies) as a property. 

If we want to access it on Arango queries, it must be stored as an object, which is not possible via CSV import.

Since Biocypher only supports CSV outputs, I wrote an independent JSON output, all the ontology functionalities continue to work, just the writer of the file that was changed.