### PR TITLE
DSERV-232 Adding check for numbers exceeding 64-bit limitation

### DIFF
--- a/data/adapters/gtex_eqtl_adapter.py
+++ b/data/adapters/gtex_eqtl_adapter.py
@@ -1,7 +1,8 @@
 import csv
 
 from adapters import Adapter
-from adapters.helpers import build_variant_id
+from adapters.helpers import build_variant_id, to_float
+
 
 # Example QTEx eQTL input file:
 # variant_id      gene_id tss_distance    ma_samples      ma_count        maf     pval_nominal    slope   slope_se        pval_nominal_threshold  min_pval_nominal        pval_beta
@@ -47,9 +48,9 @@ class GtexEQtl(Adapter):
                     _props = {
                         'biological_context': self.biological_context,
                         'chr': chr,
-                        'p_value': row[6],
-                        'slope': row[7],
-                        'beta': row[-1],
+                        'p_value': to_float(row[6]),
+                        'slope': to_float(row[7]),
+                        'beta': to_float(row[-1]),
                         'label': 'eQTL',
                         'source': 'GTEx',
                         'source_url': 'https://www.gtexportal.org/home/datasets'

--- a/data/adapters/gtex_sqtl_adapter.py
+++ b/data/adapters/gtex_sqtl_adapter.py
@@ -1,6 +1,6 @@
 import gzip
 from adapters import Adapter
-from adapters.helpers import build_variant_id
+from adapters.helpers import build_variant_id, to_float
 
 # The splice QTLs from GTEx are here: https://storage.googleapis.com/gtex_analysis_v8/single_tissue_qtl_data/GTEx_Analysis_v8_sQTL.tar
 # All the files use assembly grch38
@@ -58,13 +58,13 @@ class GtexSQtl(Adapter):
                     _props = {
                         'chr': variant_id_ls[0],
                         'biological_context': self.tissue,
-                        'sqrt_maf': line_ls[5],
-                        'p_value': line_ls[6],
-                        'pval_nominal_threshold': line_ls[9],
-                        'min_pval_nominal': line_ls[10],
-                        'slope': line_ls[7],
-                        'slope_se': line_ls[8],
-                        'beta': line_ls[11],
+                        'sqrt_maf': to_float(line_ls[5]),
+                        'p_value': to_float(line_ls[6]),
+                        'pval_nominal_threshold': to_float(line_ls[9]),
+                        'min_pval_nominal': to_float(line_ls[10]),
+                        'slope': to_float(line_ls[7]),
+                        'slope_se': to_float(line_ls[8]),
+                        'beta': to_float(line_ls[11]),
                         'intron_chr': phenotype_id_ls[0],
                         'intron_start': phenotype_id_ls[1],
                         'intron_end': phenotype_id_ls[2],

--- a/data/tests/test_helpers.py
+++ b/data/tests/test_helpers.py
@@ -65,7 +65,7 @@ def test_to_float_adapts_exponent_correctly():
     assert to_float(number) == float(number)
 
     number = float('3.14e-310')
-    assert to_float(number) == (number * 100)  # 3.14e-308
+    assert to_float(number) == (number * 1000)  # 3.14e-307
 
     number = float('3.14e-400')
     assert to_float(number) == 0

--- a/data/tests/test_helpers.py
+++ b/data/tests/test_helpers.py
@@ -1,6 +1,6 @@
 import pytest
 import hashlib
-from adapters.helpers import build_variant_id, build_regulatory_region_id
+from adapters.helpers import build_variant_id, build_regulatory_region_id, to_float
 
 
 def test_build_variant_id_fails_for_unsupported_assembly():
@@ -49,3 +49,23 @@ def test_build_regulatory_region_id_fails_for_unsupported_assembly():
         build_regulatory_region_id(None, None, None, None)
     except:
         assert False, 'build_regulatory_region_id raised exception for GRCh38'
+
+
+def test_to_float_adapts_exponent_correctly():
+    number = '3.14'
+    assert to_float('3.14') == 3.14
+
+    number = '3.14e10'
+    assert to_float(number) == float(number)
+
+    number = '3.14e400'
+    assert to_float(number) == float('1e307')
+
+    number = '3.14e-10'
+    assert to_float(number) == float(number)
+
+    number = float('3.14e-310')
+    assert to_float(number) == (number * 100)  # 3.14e-308
+
+    number = float('3.14e-400')
+    assert to_float(number) == 0


### PR DESCRIPTION
Certain numbers are being passed to Arango as strings that can't be represented in a 64-bit double value. 
We are rounding such numbers so they can be ingested correctly.