### PR TITLE
DSERV-273 Fix QTL timeout when querying intervals

### DIFF
--- a/src/routers/datatypeRouters/edges/variants_genes.ts
+++ b/src/routers/datatypeRouters/edges/variants_genes.ts
@@ -99,7 +99,7 @@ async function conditionalSearch (input: paramsFormatType, type: string): Promis
     return await routerEqtls.getEdgeObjects(input, '', verbose)
   }
 
-  const preProcessed = preProcessRegionParam({ ...input, ...{ sort: 'chr' } }, null, 'intron')
+  const preProcessed = preProcessRegionParam({ ...input, ...{ sort: '_key' } }, null, 'intron')
 
   if (type === 'sqtl') {
     input.label = 'splice_QTL'


### PR DESCRIPTION
Sorting by _key will use the built-in ArangoDB index sufficiently speeding up the query