### PR TITLE
DSERV-790-prompt-limit

### DIFF
--- a/catalog_llm_query/prompt_template.py
+++ b/catalog_llm_query/prompt_template.py
@@ -1,0 +1,44 @@
+from langchain_core.prompts import PromptTemplate
+
+AQL_GENERATION_TEMPLATE = """Task: Generate an ArangoDB Query Language (AQL) query from a User Input.
+
+You are an ArangoDB Query Language (AQL) expert responsible for translating a `User Input` into an ArangoDB Query Language (AQL) query.
+
+You are given an `ArangoDB Schema`. It is a JSON Object containing:
+1. `Graph Schema`: Lists all Graphs within the ArangoDB Database Instance, along with their Edge Relationships.
+2. `Collection Schema`: Lists all Collections within the ArangoDB Database Instance, along with their document/edge properties and a document/edge example.
+
+You also are given a set of `AQL Query Examples` to help you create the `AQL Query`. If provided, the `AQL Query Examples` should be used as a reference, similar to how `ArangoDB Schema` should be used.
+
+Things you should do:
+- Think step by step.
+- Rely on `ArangoDB Schema` and `AQL Query Examples` (if provided) to generate the query.
+- Begin the `AQL Query` by the `WITH` AQL keyword to specify all of the ArangoDB Collections required.
+- Always add 'LIMIT 5' before return for every query, ensuring that no more than 5 results are returned.
+- Return the `AQL Query` wrapped in 3 backticks (```).
+- Learn from `AQL Query Examples` queries.
+- Only answer to requests related to generating an AQL Query.
+- If a request is unrelated to generating AQL Query, say that you cannot help the user.
+
+Things you should not do:
+- Do not use any properties/relationships that can't be inferred from the `ArangoDB Schema` or the `AQL Query Examples`.
+- Do not include any text except the generated AQL Query.
+- Do not provide explanations or apologies in your responses.
+- Do not generate an AQL Query that removes or deletes any data.
+
+Under no circumstance should you generate an AQL Query that deletes any data whatsoever.
+
+
+AQL Query Examples (Optional):
+{aql_examples}
+
+User Input:
+{user_input}
+
+AQL Query:
+"""
+
+AQL_GENERATION_PROMPT = PromptTemplate(
+    input_variables=['aql_examples', 'user_input'],
+    template=AQL_GENERATION_TEMPLATE,
+)


### PR DESCRIPTION
Even you set the limit in example, llm will not alway set the limit. Some query will run out of time because of it. Will need to tell llm to add limit in prompt. Set limit to 5 to limit output context as well.

One strange thing is since we customized the AQL generation prompt, the chain still expects a query input. However, query should be generated by the model and not provided manually. I have to still add a query key in order to invoke the chain.

Will merge to DSERV-780-flask-deploy for all the llm related branch.