### PR TITLE
DSERV-908 Removing old protein_id constraint from coding-variants api

### DIFF
--- a/src/routers/datatypeRouters/nodes/coding_variants.ts
+++ b/src/routers/datatypeRouters/nodes/coding_variants.ts
@@ -85,28 +85,14 @@ async function queryCodingVariants (input: paramsFormatType): Promise<any[]> {
     filters = `FILTER ${filters}`
   }
 
-  let query
-  if (input.protein_id !== undefined) {
-    const proteinId = `proteins/${input.protein_id as string}`
-    query = `
-      FOR record IN ${codingVariantSchema.db_collection_name as string}
-          FILTER record._id IN (
-            FOR edge IN coding_variants_proteins
-              FILTER edge._to == '${proteinId}'
-              RETURN edge._from
-          )
-        SORT record.gene_name, record.aapos
-        LIMIT ${input.page as number * limit}, ${limit}
-        RETURN {${getDBReturnStatements(codingVariantSchema)}}`
-  } else {
-    query = `
+  const query = `
       FOR record IN ${codingVariantSchema.db_collection_name as string}
       ${filters}
       SORT record.gene_name, record.aapos
       LIMIT ${input.page as number * limit}, ${limit}
       RETURN {${getDBReturnStatements(codingVariantSchema)}}
     `
-  }
+
   const cursor = await db.query(query)
   return await cursor.all()
 }


### PR DESCRIPTION
Protein_id is part of coding_variants, no need to query externally