### PR TITLE
DSERV-870 Using persistent index for genomic region search

### DIFF
--- a/data/index-config.yaml
+++ b/data/index-config.yaml
@@ -265,9 +265,7 @@ genomic_elements:
       - chr, type, source_annotation
       - type, source_annotation
       - source_annotation, _key
-  zkd_sparse:
-    fields:
-      - start,end
+      - chr, start, end
 
 genomic_elements_biosamples:
   persistent:

--- a/src/routers/datatypeRouters/nodes/genomic_elements.ts
+++ b/src/routers/datatypeRouters/nodes/genomic_elements.ts
@@ -7,7 +7,6 @@ import { descriptions } from '../descriptions'
 import { QUERY_LIMIT } from '../../../constants'
 import { sourceAnnotation, commonNodesParamsFormat, genomicElementSource, genomicElementType } from '../params'
 
-export const ZKD_INDEX = 'idx_zkd_start_end'
 const MAX_PAGE_SIZE = 1000
 
 const schema = loadSchemaConfig()
@@ -40,11 +39,6 @@ async function genomicElementSearch (input: paramsFormatType): Promise<any[]> {
   }
   delete input.organism
 
-  let useIndex = ''
-  if (input.region !== undefined) {
-    useIndex = `OPTIONS { indexHint: "${ZKD_INDEX}", forceIndexHint: true }`
-  }
-
   let limit = QUERY_LIMIT
   if (input.limit !== undefined) {
     limit = (input.limit as number <= MAX_PAGE_SIZE) ? input.limit as number : MAX_PAGE_SIZE
@@ -58,7 +52,7 @@ async function genomicElementSearch (input: paramsFormatType): Promise<any[]> {
   }
 
   const query = `
-    FOR record IN ${schema.db_collection_name as string} ${useIndex}
+    FOR record IN ${schema.db_collection_name as string}
     ${filterBy}
     SORT record._key
     LIMIT ${input.page as number * limit}, ${limit}


### PR DESCRIPTION
Turns out when you need consistent pagination (filter + sort), persistent indices are faster than zkd/mdi.
Pure sorting is faster on an mdi, but the sorting is highly inefficient.