### PR TITLE
DSERV-1153-GersbachE2GCRISPR

### DIFF
--- a/data/adapters/file_fileset_adapter.py
+++ b/data/adapters/file_fileset_adapter.py
@@ -73,7 +73,7 @@ class FileFileSet:
     }
     METHOD_TO_COLLECTIONS_ENCODE = {
         'caQTL': ['variants_genomic_elements', 'genomic_elements'],
-        'CRISPR enhancer perturbation screens': ['genomic_elements', 'genomic_elements_genes'],
+        'CRISPR enhancer perturbation screen': ['genomic_elements', 'genomic_elements_genes'],
         'MPRA': ['genomic_elements_biosamples', 'genomic_elements'],
         'ENCODE-rE2G': ['genomic_elements', 'genomic_elements_genes'],
     }
@@ -496,7 +496,7 @@ class FileFileSet:
         all_sample_types = list(sample_term_to_sample_type.values())
         # manually set the method to ENCODE-rE2G for file ENCFF968BZL
         if accession == 'ENCFF968BZL':
-            method = 'CRISPR enhancer perturbation screens'
+            method = 'CRISPR enhancer perturbation screen'
 
         if accession == 'ENCFF420VPZ':
             catalog_collections = ['genomic_elements']

--- a/data/adapters/gersbach_E2G_CRISPR_adapter.py
+++ b/data/adapters/gersbach_E2G_CRISPR_adapter.py
@@ -129,7 +129,7 @@ class GersbachE2GCRISPR(BaseAdapter):
 
                 if method == 'Perturb-seq':
                     metrics = {
-                        'p_val': float(row[I['p_val']]),
+                        'p_value': float(row[I['p_val']]),
                         'avg_log2FC': float(row[I['avg_log2FC']]),
                         'pct_1': float(row[I['pct_1']]),
                         'pct_2': float(row[I['pct_2']]),
@@ -137,7 +137,7 @@ class GersbachE2GCRISPR(BaseAdapter):
                     }
                 elif method == 'CRISPR FACS screen':
                     metrics = {
-                        'p_val': float(row[I['p_val']]),
+                        'p_value': float(row[I['p_val']]),
                         'p_val_adj': float(row[I['p_val_adj']]),
                         'effect_size': float(row[I['effect_size']])
                     }

--- a/data/adapters/gersbach_E2G_CRISPR_adapter.py
+++ b/data/adapters/gersbach_E2G_CRISPR_adapter.py
@@ -133,12 +133,12 @@ class GersbachE2GCRISPR(BaseAdapter):
                         'avg_log2FC': float(row[I['avg_log2FC']]),
                         'pct_1': float(row[I['pct_1']]),
                         'pct_2': float(row[I['pct_2']]),
-                        'p_val_adj': float(row[I['p_val_adj']]),
+                        'p_value_adj': float(row[I['p_val_adj']]),
                     }
                 elif method == 'CRISPR FACS screen':
                     metrics = {
                         'p_value': float(row[I['p_val']]),
-                        'p_val_adj': float(row[I['p_val_adj']]),
+                        'p_value_adj': float(row[I['p_val_adj']]),
                         'effect_size': float(row[I['effect_size']])
                     }
 

--- a/data/data_sources/data_sources_file_fileset.yaml
+++ b/data/data_sources/data_sources_file_fileset.yaml
@@ -1844,5 +1844,5 @@ encode_file_accessions:
   candidate Cis-Regulatory Elements:
     - ENCFF167FJQ
     - ENCFF420VPZ
-  CRISPR enhancer perturbation screens:
+  CRISPR enhancer perturbation screen:
     - ENCFF968BZL

--- a/data/schemas/edges/genomic_elements_genes.ENCODE2GCRISPR.json
+++ b/data/schemas/edges/genomic_elements_genes.ENCODE2GCRISPR.json
@@ -45,7 +45,7 @@
         },
         "method": {
           "enum": [
-            "CRISPR enhancer perturbation screens"
+            "CRISPR enhancer perturbation screen"
           ]
         },
         "class": {

--- a/data/schemas/edges/genomic_elements_genes.GersbachE2GCRISPR.json
+++ b/data/schemas/edges/genomic_elements_genes.GersbachE2GCRISPR.json
@@ -101,7 +101,7 @@
           "type": "number",
           "description": "The percentage of the genomic element to gene edge"
         },
-        "p_val_adj": {
+        "p_value_adj": {
           "type": "number",
           "description": "The adjusted p-value of the genomic element to gene edge"
         },
@@ -117,7 +117,7 @@
         "biological_context",
         "treatments_term_ids",
         "p_value",
-        "p_val_adj"
+        "p_value_adj"
       ],
       "additionalProperties": false
     }

--- a/data/schemas/edges/genomic_elements_genes.GersbachE2GCRISPR.json
+++ b/data/schemas/edges/genomic_elements_genes.GersbachE2GCRISPR.json
@@ -85,7 +85,7 @@
           ],
           "description": "The treatments term ids of the genomic element to gene edge"
         },
-        "p_val": {
+        "p_value": {
           "type": "number",
           "description": "The p-value of the genomic element to gene edge"
         },
@@ -116,7 +116,7 @@
         "biosample_term",
         "biological_context",
         "treatments_term_ids",
-        "p_val",
+        "p_value",
         "p_val_adj"
       ],
       "additionalProperties": false

--- a/data/schemas/edges/genomic_elements_genes.GersbachE2GCRISPR.json
+++ b/data/schemas/edges/genomic_elements_genes.GersbachE2GCRISPR.json
@@ -91,7 +91,7 @@
         },
         "avg_log2FC": {
           "type": "number",
-          "description": "The average log2 fold change of the genomic element to gene edge"
+          "description": "The average log2 fold change of the genomic element to gene edge. This is used as score in APIs for data with method 'Perturb-seq'."
         },
         "pct_1": {
           "type": "number",
@@ -107,7 +107,7 @@
         },
         "effect_size": {
           "type": "number",
-          "description": "The effect size of the genomic element to gene edge"
+          "description": "The effect size of the genomic element to gene edge. This is used as score in APIs for data with method 'CRISPR FACS screen'."
         }
       },
       "required": [

--- a/data/schemas/nodes/genomic_elements.ENCODE2GCRISPR.json
+++ b/data/schemas/nodes/genomic_elements.ENCODE2GCRISPR.json
@@ -21,7 +21,7 @@
         },
         "method": {
           "enum": [
-            "CRISPR enhancer perturbation screens"
+            "CRISPR enhancer perturbation screen"
           ]
         }
       },

--- a/data/tests/test_encode_E2G_CRISPR_adapter.py
+++ b/data/tests/test_encode_E2G_CRISPR_adapter.py
@@ -11,7 +11,7 @@ def mock_file_fileset():
     """Fixture to mock get_file_fileset_by_accession_in_arangodb function."""
     with patch('adapters.encode_E2G_CRISPR_adapter.get_file_fileset_by_accession_in_arangodb') as mock_get_file_fileset:
         mock_get_file_fileset.return_value = {
-            'method': 'CRISPR enhancer perturbation screens',
+            'method': 'CRISPR enhancer perturbation screen',
             'class': 'observed data',
             'simple_sample_summaries': ['K562'],
             'samples': ['ontology_terms/EFO_0002067']
@@ -32,7 +32,7 @@ def test_encode2gcrispr_adapter_regulatory_region(mock_file_fileset):
     assert 'start' in first_item
     assert 'end' in first_item
     assert 'type' in first_item
-    assert first_item['method'] == 'CRISPR enhancer perturbation screens'
+    assert first_item['method'] == 'CRISPR enhancer perturbation screen'
     assert first_item['source'] == ENCODE2GCRISPR.SOURCE
     assert first_item['source_url'] == ENCODE2GCRISPR.SOURCE_URL
 
@@ -57,7 +57,7 @@ def test_encode2gcrispr_adapter_regulatory_region_gene(mock_file_fileset):
     assert first_item['biological_context'] == 'K562'
     assert first_item['biosample_term'] == 'ontology_terms/EFO_0002067'
     assert first_item['label'] == 'regulatory element effect on gene expression'
-    assert first_item['method'] == 'CRISPR enhancer perturbation screens'
+    assert first_item['method'] == 'CRISPR enhancer perturbation screen'
     assert first_item['class'] == 'observed data'
 
 

--- a/data/tests/test_file_fileset_adapter.py
+++ b/data/tests/test_file_fileset_adapter.py
@@ -122,7 +122,7 @@ def test_file_fileset_adapter_encode_crispr_enhancer_perturbation_screens(mock_c
         'lab': 'jesse-engreitz',
         'preferred_assay_titles': None,
         'assay_term_ids': None,
-        'method': 'CRISPR enhancer perturbation screens',
+        'method': 'CRISPR enhancer perturbation screen',
         'class': 'observed data',
         'software': None,
         'samples': ['ontology_terms/EFO_0002067'],

--- a/data/tests/test_gersbach_E2G_CRISPR_adapter.py
+++ b/data/tests/test_gersbach_E2G_CRISPR_adapter.py
@@ -76,7 +76,7 @@ def test_gersbach_e2g_crispr_adapter_perturb_seq_genomic_elements_genes(mock_fil
         assert first_item['avg_log2FC'] == 3.608562048
         assert first_item['pct_1'] == 0.918
         assert first_item['pct_2'] == 0.282
-        assert first_item['p_val_adj'] == 0.0
+        assert first_item['p_value_adj'] == 0.0
         assert first_item['method'] == 'Perturb-seq'
         assert first_item['biological_context'] == 'CD8-positive, alpha-beta memory T cell'
         assert first_item['biosample_term'] == 'ontology_terms/CL_0000909'
@@ -129,7 +129,7 @@ def test_gersbach_e2g_crispr_adapter_facs_screen_genomic_elements_genes(mock_fil
         assert first_item['_from'] == 'genomic_elements/CRISPR_chr1_998962_999432_GRCh38_IGVFFI9721OCVW'
         assert first_item['_to'] == 'genes/ENSG00000126353'
         assert first_item['p_value'] == 0.7264835
-        assert first_item['p_val_adj'] == 0.9994257067617868
+        assert first_item['p_value_adj'] == 0.9994257067617868
         assert first_item['effect_size'] == 0.2254047296279381
         assert first_item['method'] == 'CRISPR FACS screen'
         assert first_item['biological_context'] == 'CD8-positive, alpha-beta memory T cell'

--- a/data/tests/test_gersbach_E2G_CRISPR_adapter.py
+++ b/data/tests/test_gersbach_E2G_CRISPR_adapter.py
@@ -72,7 +72,7 @@ def test_gersbach_e2g_crispr_adapter_perturb_seq_genomic_elements_genes(mock_fil
         assert first_item['_key'] == 'CRISPR_chr1_212699339_212700840_GRCh38_ENSG00000123685_IGVFFI6830YLEK'
         assert first_item['_from'] == 'genomic_elements/CRISPR_chr1_212699339_212700840_GRCh38_IGVFFI6830YLEK'
         assert first_item['_to'] == 'genes/ENSG00000123685'
-        assert first_item['p_val'] == 0.0
+        assert first_item['p_value'] == 0.0
         assert first_item['avg_log2FC'] == 3.608562048
         assert first_item['pct_1'] == 0.918
         assert first_item['pct_2'] == 0.282
@@ -128,7 +128,7 @@ def test_gersbach_e2g_crispr_adapter_facs_screen_genomic_elements_genes(mock_fil
         assert first_item['_key'] == 'CRISPR_chr1_998962_999432_GRCh38_ENSG00000126353_IGVFFI9721OCVW'
         assert first_item['_from'] == 'genomic_elements/CRISPR_chr1_998962_999432_GRCh38_IGVFFI9721OCVW'
         assert first_item['_to'] == 'genes/ENSG00000126353'
-        assert first_item['p_val'] == 0.7264835
+        assert first_item['p_value'] == 0.7264835
         assert first_item['p_val_adj'] == 0.9994257067617868
         assert first_item['effect_size'] == 0.2254047296279381
         assert first_item['method'] == 'CRISPR FACS screen'

--- a/src/routers/datatypeRouters/edges/genomic_elements_genes.ts
+++ b/src/routers/datatypeRouters/edges/genomic_elements_genes.ts
@@ -13,7 +13,7 @@ import { getSchema } from '../schema'
 
 const MAX_PAGE_SIZE = 500
 const METHODS = [
-  'CRISPR enhancer perturbation screens',
+  'CRISPR enhancer perturbation screen',
   'CRISPR FACS screen',
   'ENCODE-rE2G',
   'Perturb-seq'

--- a/src/routers/datatypeRouters/nodes/files_filesets.ts
+++ b/src/routers/datatypeRouters/nodes/files_filesets.ts
@@ -50,7 +50,7 @@ const METHOD = [
   'BlueSTARR',
   'candidate Cis-Regulatory Elements',
   'caQTL',
-  'CRISPR enhancer perturbation screens',
+  'CRISPR enhancer perturbation screen',
   'CRISPR FACS screen',
   'cV2F',
   'ENCODE-rE2G',

--- a/src/routers/datatypeRouters/nodes/genomic_elements.ts
+++ b/src/routers/datatypeRouters/nodes/genomic_elements.ts
@@ -17,7 +17,7 @@ const METHODS = [
   'caQTL',
   'CRISPR FACS screen',
   'Perturb-seq',
-  'CRISPR enhancer perturbation screens'
+  'CRISPR enhancer perturbation screen'
 ] as const
 
 export const genomicElementsQueryFormat = z.object({


### PR DESCRIPTION
Two major update:
1. change method **CRISPR enhancer perturbation screens** to **CRISPR enhancer perturbation screen**
2. change **p_val** to **p_value** in **GersbachE2GCRISPR** so it is same with adapter **ENCODE2GCRISPR**